### PR TITLE
Update Python3 starter for multi-units (fwd model starter unchanged)

### DIFF
--- a/base-compose.yml
+++ b/base-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     game-server:
-        image: coderone.azurecr.io/game-server:622
+        image: coderone.azurecr.io/game-server:694
 
     python3-agent:
         build:

--- a/base-compose.yml
+++ b/base-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     game-server:
-        image: coderone.azurecr.io/game-server:384
+        image: coderone.azurecr.io/game-server:622
 
     python3-agent:
         build:

--- a/python3/test_game_state.py
+++ b/python3/test_game_state.py
@@ -15,36 +15,30 @@ def create_mock_tick_packet(tick_number, events):
         "tick": tick_number, "events": copy_object(events)}}
 
 
-mock_state = {"agent_state": {"0": {"coordinates": [6, 7], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "number": 0, "invulnerability": 0}, "1": {"coordinates": [6, 6], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "number": 1, "invulnerability": 0}}, "entities": [{"x": 8, "y": 4, "type": "m"}, {"x": 2, "y": 5, "type": "m"}, {"x": 2, "y": 6, "type": "m"}, {"x": 2, "y": 7, "type": "m"}, {"x": 1, "y": 5, "type": "m"}, {"x": 6, "y": 8, "type": "m"}, {"x": 4, "y": 4, "type": "m"}, {"x": 8, "y": 6, "type": "m"}, {"x": 3, "y": 3, "type": "m"}, {"x": 0, "y": 5, "type": "m"}, {"x": 8, "y": 2, "type": "m"}, {"x": 1, "y": 8, "type": "m"}, {"x": 2, "y": 2, "type": "m"}, {"x": 5, "y": 6, "type": "m"}, {"x": 3, "y": 0, "type": "m"}, {"x": 2, "y": 8, "type": "m"}, {"x": 8, "y": 1, "type": "m"}, {
-    "x": 6, "y": 2, "type": "w"}, {"x": 2, "y": 3, "type": "w"}, {"x": 3, "y": 5, "type": "w"}, {"x": 7, "y": 6, "type": "w"}, {"x": 4, "y": 3, "type": "w"}, {"x": 0, "y": 3, "type": "w"}, {"x": 5, "y": 3, "type": "w"}, {"x": 3, "y": 2, "type": "w"}, {"x": 5, "y": 5, "type": "w"}, {"x": 8, "y": 7, "type": "w"}, {"x": 3, "y": 7, "type": "w"}, {"x": 1, "y": 7, "type": "w"}, {"x": 4, "y": 0, "type": "w"}, {"x": 3, "y": 6, "type": "w"}, {"x": 0, "y": 0, "type": "w"}, {"x": 7, "y": 5, "type": "w"}, {"x": 3, "y": 4, "type": "w"}, {"x": 0, "y": 8, "type": "w"}, {"x": 8, "y": 3, "type": "w"}, {"x": 6, "y": 0, "type": "w"}, {"x": 1, "y": 4, "type": "o"}, {"x": 0, "y": 4, "type": "o"}, {"x": 3, "y": 8, "type": "o"}, {"x": 0, "y": 2, "type": "o"}, {"x": 4, "y": 7, "type": "o"}], "world": {"width": 9, "height": 9}, "connection": {"id": 7, "role": "agent", "agent_number": 0},
-    "tick": 0,
-    "config": {
-    "tick_rate_hz": 20,
-    "game_duration_ticks": 10,
-    "fire_spawn_interval_ticks": 5
-}}
-
+mock_state = {"agents": {"a": {"agent_id": "a", "unit_ids": ["c", "e", "g"]}, "b": {"agent_id": "b", "unit_ids": ["d", "f", "h"]}}, "unit_state": {"c": {"coordinates": [3, 10], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "unit_id": "c", "agent_id": "a", "invulnerability": 0}, "d": {"coordinates": [11, 10], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "unit_id": "d", "agent_id": "b", "invulnerability": 0}, "e": {"coordinates": [1, 9], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "unit_id": "e", "agent_id": "a", "invulnerability": 0}, "f": {"coordinates": [13, 9], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "unit_id": "f", "agent_id": "b", "invulnerability": 0}, "g": {"coordinates": [12, 7], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "unit_id": "g", "agent_id": "a", "invulnerability": 0}, "h": {"coordinates": [2, 7], "hp": 3, "inventory": {"bombs": 3}, "blast_diameter": 3, "unit_id": "h", "agent_id": "b", "invulnerability": 0}}, "entities": [{"created": 0, "x": 11, "y": 7, "type": "m"}, {"created": 0, "x": 3, "y": 7, "type": "m"}, {"created": 0, "x": 10, "y": 11, "type": "m"}, {"created": 0, "x": 4, "y": 11, "type": "m"}, {"created": 0, "x": 11, "y": 2, "type": "m"}, {"created": 0, "x": 3, "y": 2, "type": "m"}, {"created": 0, "x": 4, "y": 8, "type": "m"}, {"created": 0, "x": 10, "y": 8, "type": "m"}, {"created": 0, "x": 14, "y": 14, "type": "m"}, {"created": 0, "x": 0, "y": 14, "type": "m"}, {"created": 0, "x": 13, "y": 13, "type": "m"}, {"created": 0, "x": 1, "y": 13, "type": "m"}, {"created": 0, "x": 14, "y": 0, "type": "m"}, {"created": 0, "x": 0, "y": 0, "type": "m"}, {"created": 0, "x": 2, "y": 3, "type": "m"}, {"created": 0, "x": 12, "y": 3, "type": "m"}, {"created": 0, "x": 3, "y": 14, "type": "m"}, {"created": 0, "x": 11, "y": 14, "type": "m"}, {"created": 0, "x": 0, "y": 1, "type": "m"}, {"created": 0, "x": 14, "y": 1, "type": "m"}, {"created": 0, "x": 5, "y": 2, "type": "m"}, 
+    {"created": 0, "x": 9, "y": 2, "type": "m"}, {"created": 0, "x": 9, "y": 6, "type": "m"}, {"created": 0, "x": 5, "y": 6, "type": "m"}, {"created": 0, "x": 11, "y": 13, "type": "m"}, {"created": 0, "x": 
+    3, "y": 13, "type": "m"}, {"created": 0, "x": 2, "y": 10, "type": "m"}, {"created": 0, "x": 12, "y": 10, "type": "m"}, {"created": 0, "x": 2, "y": 13, "type": "m"}, {"created": 0, "x": 12, "y": 13, "type": "m"}, {"created": 0, "x": 12, "y": 6, "type": "m"}, {"created": 0, "x": 2, "y": 6, "type": "m"}, {"created": 0, "x": 1, "y": 10, "type": "m"}, {"created": 0, "x": 13, "y": 10, "type": "m"}, {"created": 0, "x": 1, "y": 6, "type": "m"}, {"created": 0, "x": 13, "y": 6, "type": "m"}, {"created": 0, "x": 9, "y": 12, "type": "m"}, {"created": 0, "x": 5, "y": 12, "type": "m"}, {"created": 0, "x": 1, "y": 0, "type": "m"}, {"created": 0, "x": 13, "y": 0, "type": "m"}, {"created": 0, "x": 14, "y": 2, "type": "m"}, {"created": 0, "x": 0, "y": 2, "type": "m"}, {"created": 0, "x": 10, "y": 1, "type": "m"}, {"created": 0, "x": 4, "y": 1, "type": "m"}, {"created": 0, "x": 11, "y": 8, "type": "m"}, {"created": 0, "x": 3, "y": 8, "type": "m"}, {"created": 0, "x": 0, "y": 6, "type": "m"}, {"created": 0, "x": 14, "y": 6, "type": "m"}, {"created": 0, "x": 12, "y": 5, "type": "m"}, {"created": 0, "x": 2, "y": 5, "type": "m"}, {"created": 0, "x": 1, "y": 3, "type": "w", "hp": 1}, {"created": 0, "x": 13, "y": 3, "type": "w", "hp": 1}, {"created": 0, "x": 1, "y": 8, "type": "w", "hp": 1}, {"created": 0, "x": 13, "y": 8, "type": "w", "hp": 1}, {"created": 0, "x": 0, "y": 8, "type": "w", "hp": 1}, {"created": 0, "x": 14, "y": 8, "type": "w", "hp": 1}, {"created": 0, "x": 6, "y": 3, "type": "w", "hp": 1}, {"created": 0, "x": 8, "y": 3, "type": "w", "hp": 1}, {"created": 0, "x": 6, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 8, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 9, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 5, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 13, "y": 14, "type": "w", "hp": 1}, {"created": 0, "x": 1, "y": 14, "type": "w", "hp": 1}, {"created": 0, "x": 5, "y": 9, "type": "w", "hp": 1}, {"created": 0, "x": 9, "y": 9, "type": "w", "hp": 1}, {"created": 0, "x": 3, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 11, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 13, "y": 11, "type": "w", "hp": 1}, {"created": 0, "x": 1, "y": 11, "type": "w", "hp": 1}, {"created": 0, "x": 8, "y": 12, "type": "w", "hp": 1}, {"created": 0, "x": 6, "y": 12, "type": "w", "hp": 1}, {"created": 0, "x": 14, "y": 3, "type": "w", "hp": 1}, {"created": 0, "x": 0, "y": 3, "type": "w", 
+    "hp": 1}, {"created": 0, "x": 10, "y": 13, "type": "w", "hp": 1}, {"created": 0, "x": 4, "y": 13, "type": "w", "hp": 1}, {"created": 0, "x": 14, "y": 13, "type": "w", "hp": 1}, {"created": 0, "x": 0, "y": 13, "type": "w", "hp": 1}, {"created": 0, "x": 10, "y": 14, "type": "w", "hp": 1}, {"created": 0, "x": 4, "y": 14, "type": "w", "hp": 1}, {"created": 0, "x": 5, "y": 3, "type": "w", "hp": 1}, {"created": 0, "x": 9, "y": 3, "type": "w", "hp": 1}, {"created": 0, "x": 2, "y": 11, "type": "w", "hp": 1}, {"created": 0, "x": 12, "y": 11, "type": "w", "hp": 1}, {"created": 0, "x": 10, "y": 2, "type": "w", "hp": 1}, {"created": 0, "x": 4, "y": 2, "type": "w", "hp": 1}, {"created": 0, "x": 9, "y": 0, "type": "w", "hp": 1}, {"created": 0, "x": 5, "y": 0, "type": "w", "hp": 1}, {"created": 0, "x": 1, "y": 4, "type": "w", "hp": 1}, {"created": 0, "x": 13, "y": 4, "type": "w", "hp": 1}, {"created": 0, "x": 1, "y": 2, "type": "w", "hp": 1}, {"created": 0, "x": 13, "y": 2, "type": "w", "hp": 1}, {"created": 0, "x": 8, "y": 5, "type": "w", "hp": 1}, {"created": 0, "x": 6, "y": 5, "type": "w", "hp": 1}, {"created": 0, "x": 6, "y": 2, "type": "w", "hp": 1}, {"created": 0, "x": 8, "y": 2, "type": "w", "hp": 1}, {"created": 0, "x": 0, "y": 4, "type": "w", "hp": 1}, {"created": 0, "x": 14, "y": 4, "type": "w", "hp": 1}, {"created": 0, "x": 13, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 1, "y": 1, "type": "w", "hp": 1}, {"created": 0, "x": 5, "y": 14, "type": "w", "hp": 1}, {"created": 0, "x": 9, "y": 14, "type": "w", "hp": 1}, {"created": 0, "x": 14, "y": 11, "type": "w", "hp": 1}, {"created": 0, "x": 0, "y": 11, "type": "w", "hp": 1}, {"created": 0, "x": 5, "y": 5, "type": "w", "hp": 1}, {"created": 0, "x": 9, "y": 5, "type": "w", "hp": 1}, {"created": 0, "x": 10, "y": 4, "type": "o", "hp": 3}, {"created": 0, "x": 4, "y": 4, "type": "o", "hp": 3}, {"created": 0, "x": 9, "y": 11, "type": "o", "hp": 3}, {"created": 0, "x": 5, "y": 11, "type": "o", "hp": 3}, {"created": 0, "x": 4, "y": 12, "type": "o", "hp": 3}, {"created": 0, "x": 10, "y": 12, "type": "o", "hp": 3}, {"created": 0, "x": 2, "y": 1, "type": "o", "hp": 3}, {"created": 0, "x": 12, "y": 1, "type": "o", "hp": 3}, {"created": 0, "x": 10, "y": 6, "type": "o", "hp": 3}, {"created": 0, "x": 4, "y": 6, "type": "o", "hp": 3}, {"created": 0, "x": 11, "y": 3, "type": "o", "hp": 3}, {"created": 0, "x": 3, "y": 3, "type": "o", "hp": 3}, {"created": 0, "x": 2, "y": 4, "type": "o", "hp": 3}, {"created": 0, "x": 12, "y": 4, "type": "o", "hp": 3}], "world": {"width": 15, "height": 15}, "tick": 0, "config": {"tick_rate_hz": 10, "game_duration_ticks": 1, "fire_spawn_interval_ticks": 5}, "connection": {"id": 2, "role": "agent", "agent_id": "b"}}
 
 mock_state_packet = {"type": "game_state",
                      "payload": copy_object(mock_state)}
 
 
-mock_tick_spawn_packet = create_mock_tick_packet(33, [
-    {"type": "entity_spawned", "data": {"x": 5, "y": 4, "type": "a", "expires": 73}}])
+mock_tick_spawn_packet = create_mock_tick_packet(22, [
+    {"type": "entity_spawned", "data": {"created": 22, "x": 7, "y": 3, "type": "a", "expires": 62, "hp": 1}}])
+
+mock_tick_expired_packet = create_mock_tick_packet(62, [
+    {"type": "entity_expired", "data": [7, 3]}])
+
+mock_unit_state_payload = {"coordinates": [3, 10], "hp": 3, "inventory": {
+    "bombs": 2}, "blast_diameter": 3, "unit_id": "c", "agent_id": "a", "invulnerability": 0}
+
+mock_tick_unit_state_packet = create_mock_tick_packet(50, [{"type": "unit_state",
+                                                            "data": mock_unit_state_payload}])
 
 
-mock_tick_expired_packet = create_mock_tick_packet(69, [
-    {"type": "entity_expired", "data": [5, 4]}])
-
-mock_agent_state_payload = {"coordinates": [6, 7], "hp": 3, "inventory": {
-    "bombs": 2}, "blast_diameter": 3, "number": 0, "invulnerability": 0}
-
-mock_tick_agent_state_packet = create_mock_tick_packet(50, [{"type": "agent_state",
-                                                            "data": mock_agent_state_payload}])
-
-
-mock_tick_agent_action_packet = create_mock_tick_packet(
-    5, [{"type": "agent", "data": [0, {"type": "move", "move": "left"}]}])
+mock_tick_unit_action_packet = create_mock_tick_packet(
+    5, [{"type": "unit", "agent_id": "a", "data": {"type": "move", "move": "right", "unit_id": "c"}}])
 
 
 class TestGameState(IsolatedAsyncioTestCase):
@@ -66,10 +60,10 @@ class TestGameState(IsolatedAsyncioTestCase):
             validate(instance=mock_tick_spawn_packet, schema=schema.get(
                 "definitions").get("ValidServerPacket"))
 
-            validate(instance=mock_tick_agent_action_packet, schema=schema.get(
+            validate(instance=mock_tick_unit_action_packet, schema=schema.get(
                 "definitions").get("ValidServerPacket"))
 
-            validate(instance=mock_tick_agent_state_packet, schema=schema.get(
+            validate(instance=mock_tick_unit_state_packet, schema=schema.get(
                 "definitions").get("ValidServerPacket"))
 
     async def test_initial_game_state_constructor(self):
@@ -87,7 +81,7 @@ class TestGameState(IsolatedAsyncioTestCase):
         await self.client._on_data(copy_object(mock_tick_spawn_packet))
         expected = copy_object(mock_state)
         expected["entities"].append(
-            {"x": 5, "y": 4, "type": "a", "expires": 73})
+            {"created": 22, "x": 7, "y": 3, "type": "a", "expires": 62, "hp": 1})
         self.assert_object_equal(self.client._state, expected)
 
     async def test_on_game_entity_expired_packet(self):
@@ -97,19 +91,19 @@ class TestGameState(IsolatedAsyncioTestCase):
         expected = copy_object(mock_state)
         self.assert_object_equal(self.client._state, expected)
 
-    async def test_on_agent_state_packet(self):
+    async def test_on_unit_state_packet(self):
         await self.client._on_data(copy_object(mock_state_packet))
-        await self.client._on_data(copy_object(mock_tick_agent_state_packet))
+        await self.client._on_data(copy_object(mock_tick_unit_state_packet))
         expected = copy_object(mock_state)
-        expected["agent_state"]["0"] = mock_agent_state_payload
+        expected["unit_state"]["c"] = mock_unit_state_payload
         self.assert_object_equal(
             self.client._state, expected)
 
-    async def test_on_agent_move_packet(self):
+    async def test_on_unit_move_packet(self):
         await self.client._on_data(copy_object(mock_state_packet))
-        await self.client._on_data(copy_object(mock_tick_agent_action_packet))
+        await self.client._on_data(copy_object(mock_tick_unit_action_packet))
         expected = copy_object(mock_state)
-        expected["agent_state"]["0"]["coordinates"] = [5, 7]
+        expected["unit_state"]["c"]["coordinates"] = [4, 10]
         self.assert_object_equal(
             self.client._state, expected)
 

--- a/validation.schema.json
+++ b/validation.schema.json
@@ -1,6 +1,12 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
+        "IHashMapObject": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "type": "object"
+        },
         "ValidAdminPacket": {
             "anyOf": [
                 {
@@ -44,11 +50,15 @@
                                                             "move"
                                                         ],
                                                         "type": "string"
+                                                    },
+                                                    "unit_id": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "move",
-                                                    "type"
+                                                    "type",
+                                                    "unit_id"
                                                 ],
                                                 "type": "object"
                                             },
@@ -60,10 +70,14 @@
                                                             "bomb"
                                                         ],
                                                         "type": "string"
+                                                    },
+                                                    "unit_id": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
-                                                    "type"
+                                                    "type",
+                                                    "unit_id"
                                                 ],
                                                 "type": "object"
                                             },
@@ -88,23 +102,27 @@
                                                             "detonate"
                                                         ],
                                                         "type": "string"
+                                                    },
+                                                    "unit_id": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
                                                     "coordinates",
-                                                    "type"
+                                                    "type",
+                                                    "unit_id"
                                                 ],
                                                 "type": "object"
                                             }
                                         ]
                                     },
-                                    "agent_number": {
-                                        "type": "number"
+                                    "agent_id": {
+                                        "type": "string"
                                     }
                                 },
                                 "required": [
                                     "action",
-                                    "agent_number"
+                                    "agent_id"
                                 ],
                                 "type": "object"
                             },
@@ -116,10 +134,110 @@
                         "state": {
                             "additionalProperties": false,
                             "properties": {
-                                "agent_state": {
+                                "agents": {
                                     "additionalProperties": {
                                         "additionalProperties": false,
                                         "properties": {
+                                            "agent_id": {
+                                                "type": "string"
+                                            },
+                                            "unit_ids": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "agent_id",
+                                            "unit_ids"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "object"
+                                },
+                                "config": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "fire_spawn_interval_ticks": {
+                                            "type": "number"
+                                        },
+                                        "game_duration_ticks": {
+                                            "type": "number"
+                                        },
+                                        "tick_rate_hz": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "fire_spawn_interval_ticks",
+                                        "game_duration_ticks",
+                                        "tick_rate_hz"
+                                    ],
+                                    "type": "object"
+                                },
+                                "entities": {
+                                    "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "agent_id": {
+                                                "type": "string"
+                                            },
+                                            "blast_diameter": {
+                                                "type": "number"
+                                            },
+                                            "created": {
+                                                "type": "number"
+                                            },
+                                            "expires": {
+                                                "type": "number"
+                                            },
+                                            "hp": {
+                                                "type": "number"
+                                            },
+                                            "type": {
+                                                "enum": [
+                                                    "a",
+                                                    "b",
+                                                    "bp",
+                                                    "m",
+                                                    "o",
+                                                    "t",
+                                                    "w",
+                                                    "x"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "unit_id": {
+                                                "type": "string"
+                                            },
+                                            "x": {
+                                                "type": "number"
+                                            },
+                                            "y": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "created",
+                                            "type",
+                                            "x",
+                                            "y"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "tick": {
+                                    "type": "number"
+                                },
+                                "unit_state": {
+                                    "additionalProperties": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "agent_id": {
+                                                "type": "string"
+                                            },
                                             "blast_diameter": {
                                                 "type": "number"
                                             },
@@ -154,89 +272,22 @@
                                             "invulnerability": {
                                                 "type": "number"
                                             },
-                                            "number": {
-                                                "type": "number"
+                                            "unit_id": {
+                                                "type": "string"
                                             }
                                         },
                                         "required": [
+                                            "agent_id",
                                             "blast_diameter",
                                             "coordinates",
                                             "hp",
                                             "inventory",
                                             "invulnerability",
-                                            "number"
+                                            "unit_id"
                                         ],
                                         "type": "object"
                                     },
                                     "type": "object"
-                                },
-                                "config": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "fire_spawn_interval_ticks": {
-                                            "type": "number"
-                                        },
-                                        "game_duration_ticks": {
-                                            "type": "number"
-                                        },
-                                        "tick_rate_hz": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "required": [
-                                        "fire_spawn_interval_ticks",
-                                        "game_duration_ticks",
-                                        "tick_rate_hz"
-                                    ],
-                                    "type": "object"
-                                },
-                                "entities": {
-                                    "items": {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "blast_diameter": {
-                                                "type": "number"
-                                            },
-                                            "expires": {
-                                                "type": "number"
-                                            },
-                                            "hp": {
-                                                "type": "number"
-                                            },
-                                            "owner": {
-                                                "type": "number"
-                                            },
-                                            "type": {
-                                                "enum": [
-                                                    "a",
-                                                    "b",
-                                                    "bp",
-                                                    "m",
-                                                    "o",
-                                                    "t",
-                                                    "w",
-                                                    "x"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            "x": {
-                                                "type": "number"
-                                            },
-                                            "y": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "required": [
-                                            "type",
-                                            "x",
-                                            "y"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                },
-                                "tick": {
-                                    "type": "number"
                                 },
                                 "world": {
                                     "additionalProperties": false,
@@ -256,10 +307,11 @@
                                 }
                             },
                             "required": [
-                                "agent_state",
+                                "agents",
                                 "config",
                                 "entities",
                                 "tick",
+                                "unit_state",
                                 "world"
                             ],
                             "type": "object"
@@ -300,11 +352,15 @@
                                 "move"
                             ],
                             "type": "string"
+                        },
+                        "unit_id": {
+                            "type": "string"
                         }
                     },
                     "required": [
                         "move",
-                        "type"
+                        "type",
+                        "unit_id"
                     ],
                     "type": "object"
                 },
@@ -316,10 +372,14 @@
                                 "bomb"
                             ],
                             "type": "string"
+                        },
+                        "unit_id": {
+                            "type": "string"
                         }
                     },
                     "required": [
-                        "type"
+                        "type",
+                        "unit_id"
                     ],
                     "type": "object"
                 },
@@ -344,11 +404,15 @@
                                 "detonate"
                             ],
                             "type": "string"
+                        },
+                        "unit_id": {
+                            "type": "string"
                         }
                     },
                     "required": [
                         "coordinates",
-                        "type"
+                        "type",
+                        "unit_id"
                     ],
                     "type": "object"
                 }
@@ -368,8 +432,8 @@
                                             {
                                                 "additionalProperties": false,
                                                 "properties": {
-                                                    "agent_number": {
-                                                        "type": "number"
+                                                    "agent_id": {
+                                                        "type": "string"
                                                     },
                                                     "data": {
                                                         "anyOf": [
@@ -390,11 +454,15 @@
                                                                             "move"
                                                                         ],
                                                                         "type": "string"
+                                                                    },
+                                                                    "unit_id": {
+                                                                        "type": "string"
                                                                     }
                                                                 },
                                                                 "required": [
                                                                     "move",
-                                                                    "type"
+                                                                    "type",
+                                                                    "unit_id"
                                                                 ],
                                                                 "type": "object"
                                                             },
@@ -406,10 +474,14 @@
                                                                             "bomb"
                                                                         ],
                                                                         "type": "string"
+                                                                    },
+                                                                    "unit_id": {
+                                                                        "type": "string"
                                                                     }
                                                                 },
                                                                 "required": [
-                                                                    "type"
+                                                                    "type",
+                                                                    "unit_id"
                                                                 ],
                                                                 "type": "object"
                                                             },
@@ -434,11 +506,15 @@
                                                                             "detonate"
                                                                         ],
                                                                         "type": "string"
+                                                                    },
+                                                                    "unit_id": {
+                                                                        "type": "string"
                                                                     }
                                                                 },
                                                                 "required": [
                                                                     "coordinates",
-                                                                    "type"
+                                                                    "type",
+                                                                    "unit_id"
                                                                 ],
                                                                 "type": "object"
                                                             }
@@ -446,13 +522,13 @@
                                                     },
                                                     "type": {
                                                         "enum": [
-                                                            "agent"
+                                                            "unit"
                                                         ],
                                                         "type": "string"
                                                     }
                                                 },
                                                 "required": [
-                                                    "agent_number",
+                                                    "agent_id",
                                                     "data",
                                                     "type"
                                                 ],
@@ -512,16 +588,19 @@
                                                     "updated_entity": {
                                                         "additionalProperties": false,
                                                         "properties": {
+                                                            "agent_id": {
+                                                                "type": "string"
+                                                            },
                                                             "blast_diameter": {
+                                                                "type": "number"
+                                                            },
+                                                            "created": {
                                                                 "type": "number"
                                                             },
                                                             "expires": {
                                                                 "type": "number"
                                                             },
                                                             "hp": {
-                                                                "type": "number"
-                                                            },
-                                                            "owner": {
                                                                 "type": "number"
                                                             },
                                                             "type": {
@@ -537,6 +616,9 @@
                                                                 ],
                                                                 "type": "string"
                                                             },
+                                                            "unit_id": {
+                                                                "type": "string"
+                                                            },
                                                             "x": {
                                                                 "type": "number"
                                                             },
@@ -545,6 +627,7 @@
                                                             }
                                                         },
                                                         "required": [
+                                                            "created",
                                                             "type",
                                                             "x",
                                                             "y"
@@ -565,16 +648,19 @@
                                                     "data": {
                                                         "additionalProperties": false,
                                                         "properties": {
+                                                            "agent_id": {
+                                                                "type": "string"
+                                                            },
                                                             "blast_diameter": {
+                                                                "type": "number"
+                                                            },
+                                                            "created": {
                                                                 "type": "number"
                                                             },
                                                             "expires": {
                                                                 "type": "number"
                                                             },
                                                             "hp": {
-                                                                "type": "number"
-                                                            },
-                                                            "owner": {
                                                                 "type": "number"
                                                             },
                                                             "type": {
@@ -590,6 +676,9 @@
                                                                 ],
                                                                 "type": "string"
                                                             },
+                                                            "unit_id": {
+                                                                "type": "string"
+                                                            },
                                                             "x": {
                                                                 "type": "number"
                                                             },
@@ -598,6 +687,7 @@
                                                             }
                                                         },
                                                         "required": [
+                                                            "created",
                                                             "type",
                                                             "x",
                                                             "y"
@@ -623,6 +713,9 @@
                                                     "data": {
                                                         "additionalProperties": false,
                                                         "properties": {
+                                                            "agent_id": {
+                                                                "type": "string"
+                                                            },
                                                             "blast_diameter": {
                                                                 "type": "number"
                                                             },
@@ -657,23 +750,24 @@
                                                             "invulnerability": {
                                                                 "type": "number"
                                                             },
-                                                            "number": {
-                                                                "type": "number"
+                                                            "unit_id": {
+                                                                "type": "string"
                                                             }
                                                         },
                                                         "required": [
+                                                            "agent_id",
                                                             "blast_diameter",
                                                             "coordinates",
                                                             "hp",
                                                             "inventory",
                                                             "invulnerability",
-                                                            "number"
+                                                            "unit_id"
                                                         ],
                                                         "type": "object"
                                                     },
                                                     "type": {
                                                         "enum": [
-                                                            "agent_state"
+                                                            "unit_state"
                                                         ],
                                                         "type": "string"
                                                     }
@@ -717,10 +811,135 @@
                         "payload": {
                             "additionalProperties": false,
                             "properties": {
-                                "agent_state": {
+                                "agents": {
                                     "additionalProperties": {
                                         "additionalProperties": false,
                                         "properties": {
+                                            "agent_id": {
+                                                "type": "string"
+                                            },
+                                            "unit_ids": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "agent_id",
+                                            "unit_ids"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "object"
+                                },
+                                "config": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "fire_spawn_interval_ticks": {
+                                            "type": "number"
+                                        },
+                                        "game_duration_ticks": {
+                                            "type": "number"
+                                        },
+                                        "tick_rate_hz": {
+                                            "type": "number"
+                                        }
+                                    },
+                                    "required": [
+                                        "fire_spawn_interval_ticks",
+                                        "game_duration_ticks",
+                                        "tick_rate_hz"
+                                    ],
+                                    "type": "object"
+                                },
+                                "connection": {
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "agent_id": {
+                                            "type": "string"
+                                        },
+                                        "id": {
+                                            "type": "number"
+                                        },
+                                        "role": {
+                                            "enum": [
+                                                "admin",
+                                                "agent",
+                                                "spectator"
+                                            ],
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "agent_id",
+                                        "id",
+                                        "role"
+                                    ],
+                                    "type": "object"
+                                },
+                                "entities": {
+                                    "items": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "agent_id": {
+                                                "type": "string"
+                                            },
+                                            "blast_diameter": {
+                                                "type": "number"
+                                            },
+                                            "created": {
+                                                "type": "number"
+                                            },
+                                            "expires": {
+                                                "type": "number"
+                                            },
+                                            "hp": {
+                                                "type": "number"
+                                            },
+                                            "type": {
+                                                "enum": [
+                                                    "a",
+                                                    "b",
+                                                    "bp",
+                                                    "m",
+                                                    "o",
+                                                    "t",
+                                                    "w",
+                                                    "x"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "unit_id": {
+                                                "type": "string"
+                                            },
+                                            "x": {
+                                                "type": "number"
+                                            },
+                                            "y": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "created",
+                                            "type",
+                                            "x",
+                                            "y"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "type": "array"
+                                },
+                                "tick": {
+                                    "type": "number"
+                                },
+                                "unit_state": {
+                                    "additionalProperties": {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "agent_id": {
+                                                "type": "string"
+                                            },
                                             "blast_diameter": {
                                                 "type": "number"
                                             },
@@ -755,114 +974,22 @@
                                             "invulnerability": {
                                                 "type": "number"
                                             },
-                                            "number": {
-                                                "type": "number"
+                                            "unit_id": {
+                                                "type": "string"
                                             }
                                         },
                                         "required": [
+                                            "agent_id",
                                             "blast_diameter",
                                             "coordinates",
                                             "hp",
                                             "inventory",
                                             "invulnerability",
-                                            "number"
+                                            "unit_id"
                                         ],
                                         "type": "object"
                                     },
                                     "type": "object"
-                                },
-                                "config": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "fire_spawn_interval_ticks": {
-                                            "type": "number"
-                                        },
-                                        "game_duration_ticks": {
-                                            "type": "number"
-                                        },
-                                        "tick_rate_hz": {
-                                            "type": "number"
-                                        }
-                                    },
-                                    "required": [
-                                        "fire_spawn_interval_ticks",
-                                        "game_duration_ticks",
-                                        "tick_rate_hz"
-                                    ],
-                                    "type": "object"
-                                },
-                                "connection": {
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "agent_number": {
-                                            "type": "number"
-                                        },
-                                        "id": {
-                                            "type": "number"
-                                        },
-                                        "role": {
-                                            "enum": [
-                                                "admin",
-                                                "agent",
-                                                "spectator"
-                                            ],
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "agent_number",
-                                        "id",
-                                        "role"
-                                    ],
-                                    "type": "object"
-                                },
-                                "entities": {
-                                    "items": {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "blast_diameter": {
-                                                "type": "number"
-                                            },
-                                            "expires": {
-                                                "type": "number"
-                                            },
-                                            "hp": {
-                                                "type": "number"
-                                            },
-                                            "owner": {
-                                                "type": "number"
-                                            },
-                                            "type": {
-                                                "enum": [
-                                                    "a",
-                                                    "b",
-                                                    "bp",
-                                                    "m",
-                                                    "o",
-                                                    "t",
-                                                    "w",
-                                                    "x"
-                                                ],
-                                                "type": "string"
-                                            },
-                                            "x": {
-                                                "type": "number"
-                                            },
-                                            "y": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "required": [
-                                            "type",
-                                            "x",
-                                            "y"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    "type": "array"
-                                },
-                                "tick": {
-                                    "type": "number"
                                 },
                                 "world": {
                                     "additionalProperties": false,
@@ -882,11 +1009,12 @@
                                 }
                             },
                             "required": [
-                                "agent_state",
+                                "agents",
                                 "config",
                                 "connection",
                                 "entities",
                                 "tick",
+                                "unit_state",
                                 "world"
                             ],
                             "type": "object"
@@ -920,8 +1048,8 @@
                                                         {
                                                             "additionalProperties": false,
                                                             "properties": {
-                                                                "agent_number": {
-                                                                    "type": "number"
+                                                                "agent_id": {
+                                                                    "type": "string"
                                                                 },
                                                                 "data": {
                                                                     "anyOf": [
@@ -942,11 +1070,15 @@
                                                                                         "move"
                                                                                     ],
                                                                                     "type": "string"
+                                                                                },
+                                                                                "unit_id": {
+                                                                                    "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
                                                                                 "move",
-                                                                                "type"
+                                                                                "type",
+                                                                                "unit_id"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -958,10 +1090,14 @@
                                                                                         "bomb"
                                                                                     ],
                                                                                     "type": "string"
+                                                                                },
+                                                                                "unit_id": {
+                                                                                    "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
-                                                                                "type"
+                                                                                "type",
+                                                                                "unit_id"
                                                                             ],
                                                                             "type": "object"
                                                                         },
@@ -986,11 +1122,15 @@
                                                                                         "detonate"
                                                                                     ],
                                                                                     "type": "string"
+                                                                                },
+                                                                                "unit_id": {
+                                                                                    "type": "string"
                                                                                 }
                                                                             },
                                                                             "required": [
                                                                                 "coordinates",
-                                                                                "type"
+                                                                                "type",
+                                                                                "unit_id"
                                                                             ],
                                                                             "type": "object"
                                                                         }
@@ -998,13 +1138,13 @@
                                                                 },
                                                                 "type": {
                                                                     "enum": [
-                                                                        "agent"
+                                                                        "unit"
                                                                     ],
                                                                     "type": "string"
                                                                 }
                                                             },
                                                             "required": [
-                                                                "agent_number",
+                                                                "agent_id",
                                                                 "data",
                                                                 "type"
                                                             ],
@@ -1064,16 +1204,19 @@
                                                                 "updated_entity": {
                                                                     "additionalProperties": false,
                                                                     "properties": {
+                                                                        "agent_id": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "blast_diameter": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "created": {
                                                                             "type": "number"
                                                                         },
                                                                         "expires": {
                                                                             "type": "number"
                                                                         },
                                                                         "hp": {
-                                                                            "type": "number"
-                                                                        },
-                                                                        "owner": {
                                                                             "type": "number"
                                                                         },
                                                                         "type": {
@@ -1089,6 +1232,9 @@
                                                                             ],
                                                                             "type": "string"
                                                                         },
+                                                                        "unit_id": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "x": {
                                                                             "type": "number"
                                                                         },
@@ -1097,6 +1243,7 @@
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "created",
                                                                         "type",
                                                                         "x",
                                                                         "y"
@@ -1117,16 +1264,19 @@
                                                                 "data": {
                                                                     "additionalProperties": false,
                                                                     "properties": {
+                                                                        "agent_id": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "blast_diameter": {
+                                                                            "type": "number"
+                                                                        },
+                                                                        "created": {
                                                                             "type": "number"
                                                                         },
                                                                         "expires": {
                                                                             "type": "number"
                                                                         },
                                                                         "hp": {
-                                                                            "type": "number"
-                                                                        },
-                                                                        "owner": {
                                                                             "type": "number"
                                                                         },
                                                                         "type": {
@@ -1142,6 +1292,9 @@
                                                                             ],
                                                                             "type": "string"
                                                                         },
+                                                                        "unit_id": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "x": {
                                                                             "type": "number"
                                                                         },
@@ -1150,6 +1303,7 @@
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "created",
                                                                         "type",
                                                                         "x",
                                                                         "y"
@@ -1175,6 +1329,9 @@
                                                                 "data": {
                                                                     "additionalProperties": false,
                                                                     "properties": {
+                                                                        "agent_id": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "blast_diameter": {
                                                                             "type": "number"
                                                                         },
@@ -1209,23 +1366,24 @@
                                                                         "invulnerability": {
                                                                             "type": "number"
                                                                         },
-                                                                        "number": {
-                                                                            "type": "number"
+                                                                        "unit_id": {
+                                                                            "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "agent_id",
                                                                         "blast_diameter",
                                                                         "coordinates",
                                                                         "hp",
                                                                         "inventory",
                                                                         "invulnerability",
-                                                                        "number"
+                                                                        "unit_id"
                                                                     ],
                                                                     "type": "object"
                                                                 },
                                                                 "type": {
                                                                     "enum": [
-                                                                        "agent_state"
+                                                                        "unit_state"
                                                                     ],
                                                                     "type": "string"
                                                                 }
@@ -1255,10 +1413,110 @@
                                 "initial_state": {
                                     "additionalProperties": false,
                                     "properties": {
-                                        "agent_state": {
+                                        "agents": {
                                             "additionalProperties": {
                                                 "additionalProperties": false,
                                                 "properties": {
+                                                    "agent_id": {
+                                                        "type": "string"
+                                                    },
+                                                    "unit_ids": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "agent_id",
+                                                    "unit_ids"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "config": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "fire_spawn_interval_ticks": {
+                                                    "type": "number"
+                                                },
+                                                "game_duration_ticks": {
+                                                    "type": "number"
+                                                },
+                                                "tick_rate_hz": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "fire_spawn_interval_ticks",
+                                                "game_duration_ticks",
+                                                "tick_rate_hz"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "entities": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "agent_id": {
+                                                        "type": "string"
+                                                    },
+                                                    "blast_diameter": {
+                                                        "type": "number"
+                                                    },
+                                                    "created": {
+                                                        "type": "number"
+                                                    },
+                                                    "expires": {
+                                                        "type": "number"
+                                                    },
+                                                    "hp": {
+                                                        "type": "number"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "a",
+                                                            "b",
+                                                            "bp",
+                                                            "m",
+                                                            "o",
+                                                            "t",
+                                                            "w",
+                                                            "x"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "unit_id": {
+                                                        "type": "string"
+                                                    },
+                                                    "x": {
+                                                        "type": "number"
+                                                    },
+                                                    "y": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "created",
+                                                    "type",
+                                                    "x",
+                                                    "y"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "tick": {
+                                            "type": "number"
+                                        },
+                                        "unit_state": {
+                                            "additionalProperties": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "agent_id": {
+                                                        "type": "string"
+                                                    },
                                                     "blast_diameter": {
                                                         "type": "number"
                                                     },
@@ -1293,89 +1551,22 @@
                                                     "invulnerability": {
                                                         "type": "number"
                                                     },
-                                                    "number": {
-                                                        "type": "number"
+                                                    "unit_id": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
+                                                    "agent_id",
                                                     "blast_diameter",
                                                     "coordinates",
                                                     "hp",
                                                     "inventory",
                                                     "invulnerability",
-                                                    "number"
+                                                    "unit_id"
                                                 ],
                                                 "type": "object"
                                             },
                                             "type": "object"
-                                        },
-                                        "config": {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "fire_spawn_interval_ticks": {
-                                                    "type": "number"
-                                                },
-                                                "game_duration_ticks": {
-                                                    "type": "number"
-                                                },
-                                                "tick_rate_hz": {
-                                                    "type": "number"
-                                                }
-                                            },
-                                            "required": [
-                                                "fire_spawn_interval_ticks",
-                                                "game_duration_ticks",
-                                                "tick_rate_hz"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        "entities": {
-                                            "items": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "blast_diameter": {
-                                                        "type": "number"
-                                                    },
-                                                    "expires": {
-                                                        "type": "number"
-                                                    },
-                                                    "hp": {
-                                                        "type": "number"
-                                                    },
-                                                    "owner": {
-                                                        "type": "number"
-                                                    },
-                                                    "type": {
-                                                        "enum": [
-                                                            "a",
-                                                            "b",
-                                                            "bp",
-                                                            "m",
-                                                            "o",
-                                                            "t",
-                                                            "w",
-                                                            "x"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "x": {
-                                                        "type": "number"
-                                                    },
-                                                    "y": {
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "type",
-                                                    "x",
-                                                    "y"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "tick": {
-                                            "type": "number"
                                         },
                                         "world": {
                                             "additionalProperties": false,
@@ -1395,22 +1586,23 @@
                                         }
                                     },
                                     "required": [
-                                        "agent_state",
+                                        "agents",
                                         "config",
                                         "entities",
                                         "tick",
+                                        "unit_state",
                                         "world"
                                     ],
                                     "type": "object"
                                 },
-                                "winning_agent_number": {
-                                    "type": "number"
+                                "winning_agent_id": {
+                                    "type": "string"
                                 }
                             },
                             "required": [
                                 "history",
                                 "initial_state",
-                                "winning_agent_number"
+                                "winning_agent_id"
                             ],
                             "type": "object"
                         },
@@ -1464,10 +1656,110 @@
                                 "next_state": {
                                     "additionalProperties": false,
                                     "properties": {
-                                        "agent_state": {
+                                        "agents": {
                                             "additionalProperties": {
                                                 "additionalProperties": false,
                                                 "properties": {
+                                                    "agent_id": {
+                                                        "type": "string"
+                                                    },
+                                                    "unit_ids": {
+                                                        "items": {
+                                                            "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "agent_id",
+                                                    "unit_ids"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "object"
+                                        },
+                                        "config": {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "fire_spawn_interval_ticks": {
+                                                    "type": "number"
+                                                },
+                                                "game_duration_ticks": {
+                                                    "type": "number"
+                                                },
+                                                "tick_rate_hz": {
+                                                    "type": "number"
+                                                }
+                                            },
+                                            "required": [
+                                                "fire_spawn_interval_ticks",
+                                                "game_duration_ticks",
+                                                "tick_rate_hz"
+                                            ],
+                                            "type": "object"
+                                        },
+                                        "entities": {
+                                            "items": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "agent_id": {
+                                                        "type": "string"
+                                                    },
+                                                    "blast_diameter": {
+                                                        "type": "number"
+                                                    },
+                                                    "created": {
+                                                        "type": "number"
+                                                    },
+                                                    "expires": {
+                                                        "type": "number"
+                                                    },
+                                                    "hp": {
+                                                        "type": "number"
+                                                    },
+                                                    "type": {
+                                                        "enum": [
+                                                            "a",
+                                                            "b",
+                                                            "bp",
+                                                            "m",
+                                                            "o",
+                                                            "t",
+                                                            "w",
+                                                            "x"
+                                                        ],
+                                                        "type": "string"
+                                                    },
+                                                    "unit_id": {
+                                                        "type": "string"
+                                                    },
+                                                    "x": {
+                                                        "type": "number"
+                                                    },
+                                                    "y": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "created",
+                                                    "type",
+                                                    "x",
+                                                    "y"
+                                                ],
+                                                "type": "object"
+                                            },
+                                            "type": "array"
+                                        },
+                                        "tick": {
+                                            "type": "number"
+                                        },
+                                        "unit_state": {
+                                            "additionalProperties": {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "agent_id": {
+                                                        "type": "string"
+                                                    },
                                                     "blast_diameter": {
                                                         "type": "number"
                                                     },
@@ -1502,89 +1794,22 @@
                                                     "invulnerability": {
                                                         "type": "number"
                                                     },
-                                                    "number": {
-                                                        "type": "number"
+                                                    "unit_id": {
+                                                        "type": "string"
                                                     }
                                                 },
                                                 "required": [
+                                                    "agent_id",
                                                     "blast_diameter",
                                                     "coordinates",
                                                     "hp",
                                                     "inventory",
                                                     "invulnerability",
-                                                    "number"
+                                                    "unit_id"
                                                 ],
                                                 "type": "object"
                                             },
                                             "type": "object"
-                                        },
-                                        "config": {
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "fire_spawn_interval_ticks": {
-                                                    "type": "number"
-                                                },
-                                                "game_duration_ticks": {
-                                                    "type": "number"
-                                                },
-                                                "tick_rate_hz": {
-                                                    "type": "number"
-                                                }
-                                            },
-                                            "required": [
-                                                "fire_spawn_interval_ticks",
-                                                "game_duration_ticks",
-                                                "tick_rate_hz"
-                                            ],
-                                            "type": "object"
-                                        },
-                                        "entities": {
-                                            "items": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "blast_diameter": {
-                                                        "type": "number"
-                                                    },
-                                                    "expires": {
-                                                        "type": "number"
-                                                    },
-                                                    "hp": {
-                                                        "type": "number"
-                                                    },
-                                                    "owner": {
-                                                        "type": "number"
-                                                    },
-                                                    "type": {
-                                                        "enum": [
-                                                            "a",
-                                                            "b",
-                                                            "bp",
-                                                            "m",
-                                                            "o",
-                                                            "t",
-                                                            "w",
-                                                            "x"
-                                                        ],
-                                                        "type": "string"
-                                                    },
-                                                    "x": {
-                                                        "type": "number"
-                                                    },
-                                                    "y": {
-                                                        "type": "number"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "type",
-                                                    "x",
-                                                    "y"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "type": "array"
-                                        },
-                                        "tick": {
-                                            "type": "number"
                                         },
                                         "world": {
                                             "additionalProperties": false,
@@ -1604,10 +1829,11 @@
                                         }
                                     },
                                     "required": [
-                                        "agent_state",
+                                        "agents",
                                         "config",
                                         "entities",
                                         "tick",
+                                        "unit_state",
                                         "world"
                                     ],
                                     "type": "object"
@@ -1639,3 +1865,4 @@
         }
     }
 }
+


### PR DESCRIPTION
**Changed:**
- Bumped to game ver. 622
- Updated `agent.py` & `game_state.py` to handle multi-unit packets
- Add handling of `endgame_state` packet in `game_state.py` . Closes #32.

**Other notes:**
- Forward model starter kits to be updated in separate PR